### PR TITLE
use filter instead of map

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export function extractSinks(sinks$ : Stream<Sinks>, driverNames : string[]) : S
         .map(d => ({
         [d]: sinks$
             .map(s => s[d])
-            .filter(Boolean)
+            .filter(b => b)
             .flatten()
         }))
         .reduce((acc, curr) => Object.assign(acc, curr), {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export function extractSinks(sinks$ : Stream<Sinks>, driverNames : string[]) : S
         .map(d => ({
         [d]: sinks$
             .map(s => s[d])
-            .map(s => !s ? xs.of() : s)
+            .filter(Boolean)
             .flatten()
         }))
         .reduce((acc, curr) => Object.assign(acc, curr), {});


### PR DESCRIPTION
Filter sinks (only keep sinks that exist).
Should behave equal to old map function that maps non-existent sinks to an empty stream.
However, filter is faster and easier to understand.