### PR TITLE
prevent calling merge if one sink

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export function mergeSinks(
     const merged = Object.keys(combinedSinks)
         .filter(name => Object.keys(exceptions).indexOf(name) === -1)
         .map(s => [s, combinedSinks[s]])
-        .map(([s, arr]) => ({ [s]: xs.merge(...arr) }));
+        .map(([s, arr]) => ({ [s]: arr.length === 1 ? arr[0] : xs.merge(...arr) }));
 
     const special = Object.keys(exceptions)
         .map(key => [key, combinedSinks[key]])


### PR DESCRIPTION
I have a case where I need the sinks not to be merged when there is only one sink.